### PR TITLE
fix: add queue diagnostics, timeouts, and fix ATIS polling loop

### DIFF
--- a/source/CPDLCPlugin/ATISCache.cs
+++ b/source/CPDLCPlugin/ATISCache.cs
@@ -68,12 +68,14 @@ public class AtisCache(IClock clock, IErrorReporter errorReporter, ILogger logge
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (lastUpdatedAtisTime == controller.LastATISUpdate)
-                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
 
-            _logger.Verbose("ATIS loaded for {callsign}", controller.Callsign);
+            if (lastUpdatedAtisTime != controller.LastATISUpdate)
+            {
+                _logger.Verbose("ATIS loaded for {callsign}", controller.Callsign);
+                return controller.ATIS ?? [];
+            }
 
-            return controller.ATIS ?? [];
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
         }
     }
 

--- a/source/CPDLCPlugin/Messages/UpdateNextDataAuthorityForFdrRequest.cs
+++ b/source/CPDLCPlugin/Messages/UpdateNextDataAuthorityForFdrRequest.cs
@@ -41,6 +41,9 @@ public class UpdateNextDataAuthorityForFdrRequestHandler(
 
         var oldInfo = ourAircraft.NextDataAuthorityInfo;
 
+        using var serverCallCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        serverCallCts.CancelAfter(TimeSpan.FromSeconds(10));
+
         // Handle state transitions and error display
         if (newInfo is ErrorNextDataAuthorityInfo errorInfo)
         {
@@ -66,13 +69,11 @@ public class UpdateNextDataAuthorityForFdrRequestHandler(
                 "Transmitting NDA clear to server for {Callsign} (error state)",
                 fdr.Callsign);
 
-            using var errorStateCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            errorStateCts.CancelAfter(TimeSpan.FromSeconds(10));
             await plugin.ConnectionManager.UpdateNextDataAuthority(
                 fdr.Callsign,
                 null,
                 null,
-                errorStateCts.Token);
+                serverCallCts.Token);
 
             return;
         }
@@ -90,13 +91,11 @@ public class UpdateNextDataAuthorityForFdrRequestHandler(
                 "No ATSU boundary found for {Callsign}, clearing NDA on server",
                 fdr.Callsign);
 
-            using var noneStateCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            noneStateCts.CancelAfter(TimeSpan.FromSeconds(10));
             await plugin.ConnectionManager.UpdateNextDataAuthority(
                 fdr.Callsign,
                 null,
                 null,
-                noneStateCts.Token);
+                serverCallCts.Token);
 
             return;
         }
@@ -120,13 +119,11 @@ public class UpdateNextDataAuthorityForFdrRequestHandler(
 
             ourAircraft.SetNextDataAuthorityInfo(newInfo);
 
-            using var validStateCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            validStateCts.CancelAfter(TimeSpan.FromSeconds(10));
             await plugin.ConnectionManager.UpdateNextDataAuthority(
                 fdr.Callsign,
                 validInfo.NextDataAuthority,
                 validInfo.ExitTime,
-                validStateCts.Token);
+                serverCallCts.Token);
         }
     }
 

--- a/source/CPDLCPlugin/Messages/UpdateNextDataAuthorityForFdrRequest.cs
+++ b/source/CPDLCPlugin/Messages/UpdateNextDataAuthorityForFdrRequest.cs
@@ -66,11 +66,13 @@ public class UpdateNextDataAuthorityForFdrRequestHandler(
                 "Transmitting NDA clear to server for {Callsign} (error state)",
                 fdr.Callsign);
 
+            using var errorStateCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            errorStateCts.CancelAfter(TimeSpan.FromSeconds(10));
             await plugin.ConnectionManager.UpdateNextDataAuthority(
                 fdr.Callsign,
                 null,
                 null,
-                cancellationToken);
+                errorStateCts.Token);
 
             return;
         }
@@ -88,11 +90,13 @@ public class UpdateNextDataAuthorityForFdrRequestHandler(
                 "No ATSU boundary found for {Callsign}, clearing NDA on server",
                 fdr.Callsign);
 
+            using var noneStateCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            noneStateCts.CancelAfter(TimeSpan.FromSeconds(10));
             await plugin.ConnectionManager.UpdateNextDataAuthority(
                 fdr.Callsign,
                 null,
                 null,
-                cancellationToken);
+                noneStateCts.Token);
 
             return;
         }
@@ -116,11 +120,13 @@ public class UpdateNextDataAuthorityForFdrRequestHandler(
 
             ourAircraft.SetNextDataAuthorityInfo(newInfo);
 
+            using var validStateCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            validStateCts.CancelAfter(TimeSpan.FromSeconds(10));
             await plugin.ConnectionManager.UpdateNextDataAuthority(
                 fdr.Callsign,
                 validInfo.NextDataAuthority,
                 validInfo.ExitTime,
-                cancellationToken);
+                validStateCts.Token);
         }
     }
 

--- a/source/CPDLCPlugin/Plugin.cs
+++ b/source/CPDLCPlugin/Plugin.cs
@@ -70,7 +70,7 @@ public class Plugin : ILabelPlugin, IStripPlugin, IRecipient<DialogueChangedNoti
         WeakReferenceMessenger.Default.Register<DialogueChangedNotification>(this);
         WeakReferenceMessenger.Default.Register<ConnectedAircraftChanged>(this);
 
-        _workQueue = new WorkQueue(AddError);
+        _workQueue = new WorkQueue(AddError, Log.Logger);
     }
 
     void ConfigureServices(PluginConfiguration pluginConfiguration)

--- a/source/CPDLCPlugin/Plugin.cs
+++ b/source/CPDLCPlugin/Plugin.cs
@@ -70,7 +70,7 @@ public class Plugin : ILabelPlugin, IStripPlugin, IRecipient<DialogueChangedNoti
         WeakReferenceMessenger.Default.Register<DialogueChangedNotification>(this);
         WeakReferenceMessenger.Default.Register<ConnectedAircraftChanged>(this);
 
-        _workQueue = new WorkQueue(AddError, Log.Logger);
+        _workQueue = new WorkQueue(AddError, Log.Logger, new SystemClock());
     }
 
     void ConfigureServices(PluginConfiguration pluginConfiguration)

--- a/source/CPDLCPlugin/WorkQueue.cs
+++ b/source/CPDLCPlugin/WorkQueue.cs
@@ -1,26 +1,47 @@
-﻿using System.Threading.Channels;
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Serilog;
 
 namespace CPDLCPlugin;
 
 public class WorkQueue : IAsyncDisposable
 {
     readonly Action<Exception> _onError;
+    readonly ILogger _logger;
     readonly Channel<Func<Task>> _workQueue = Channel.CreateUnbounded<Func<Task>>();
 
     readonly CancellationTokenSource _cancellationTokenSource;
     readonly Task _worker;
 
-    public WorkQueue(Action<Exception> onError)
+    static readonly TimeSpan WaitWarningThreshold = TimeSpan.FromSeconds(2);
+    static readonly TimeSpan ExecutionWarningThreshold = TimeSpan.FromSeconds(5);
+
+    public WorkQueue(Action<Exception> onError, ILogger logger)
     {
         _onError = onError;
+        _logger = logger;
 
         _cancellationTokenSource = new CancellationTokenSource();
         _worker = Worker(_cancellationTokenSource.Token);
     }
 
-    public bool Enqueue(Func<Task> work)
+    public bool Enqueue(Func<Task> work, [CallerMemberName] string caller = "")
     {
-        return _workQueue.Writer.TryWrite(work);
+        var enqueueTime = DateTimeOffset.UtcNow;
+        return _workQueue.Writer.TryWrite(async () =>
+        {
+            var waitTime = DateTimeOffset.UtcNow - enqueueTime;
+            if (waitTime > WaitWarningThreshold)
+                _logger.Warning("[{Caller}] Work item waited {WaitMs}ms in queue", caller, (long)waitTime.TotalMilliseconds);
+
+            var sw = Stopwatch.StartNew();
+            await work();
+            sw.Stop();
+
+            if (sw.Elapsed > ExecutionWarningThreshold)
+                _logger.Warning("[{Caller}] Work item took {ElapsedMs}ms to complete", caller, sw.ElapsedMilliseconds);
+        });
     }
 
     async Task Worker(CancellationToken cancellationToken)

--- a/source/CPDLCPlugin/WorkQueue.cs
+++ b/source/CPDLCPlugin/WorkQueue.cs
@@ -9,6 +9,7 @@ public class WorkQueue : IAsyncDisposable
 {
     readonly Action<Exception> _onError;
     readonly ILogger _logger;
+    readonly IClock _clock;
     readonly Channel<Func<Task>> _workQueue = Channel.CreateUnbounded<Func<Task>>();
 
     readonly CancellationTokenSource _cancellationTokenSource;
@@ -17,10 +18,11 @@ public class WorkQueue : IAsyncDisposable
     static readonly TimeSpan WaitWarningThreshold = TimeSpan.FromSeconds(2);
     static readonly TimeSpan ExecutionWarningThreshold = TimeSpan.FromSeconds(5);
 
-    public WorkQueue(Action<Exception> onError, ILogger logger)
+    public WorkQueue(Action<Exception> onError, ILogger logger, IClock clock)
     {
         _onError = onError;
         _logger = logger;
+        _clock = clock;
 
         _cancellationTokenSource = new CancellationTokenSource();
         _worker = Worker(_cancellationTokenSource.Token);
@@ -28,10 +30,10 @@ public class WorkQueue : IAsyncDisposable
 
     public bool Enqueue(Func<Task> work, [CallerMemberName] string caller = "")
     {
-        var enqueueTime = DateTimeOffset.UtcNow;
+        var enqueueTime = _clock.UtcNow();
         return _workQueue.Writer.TryWrite(async () =>
         {
-            var waitTime = DateTimeOffset.UtcNow - enqueueTime;
+            var waitTime = _clock.UtcNow() - enqueueTime;
             if (waitTime > WaitWarningThreshold)
                 _logger.Warning("[{Caller}] Work item waited {WaitMs}ms in queue", caller, (long)waitTime.TotalMilliseconds);
 


### PR DESCRIPTION
Investigated #30. Cannot reproduce but identified a plausible root cause: the work queue is single-threaded and sequential, and `UpdateNextDataAuthority` server calls had no timeout - a slow or hanging call would stall all subsequent queue items including opening windows.

Also found a bug in `ATISCache.WaitForAtis` where the polling loop never actually looped.

Changes:
- `WorkQueue` now logs a warning (with caller name) when an item waits >2s or executes >5s, to aid future diagnosis
- All `UpdateNextDataAuthority` calls now have a 10s timeout
- Fixed `ATISCache.WaitForAtis`: the `return` was outside the `if` block, so the method always returned after at most one 1s delay regardless of whether the ATIS had updated

Closes #30