### PR TITLE
fix: prevent duplicate downlink acknowledgements

### DIFF
--- a/source/CPDLCPlugin/ViewModels/CurrentMessagesViewModel.cs
+++ b/source/CPDLCPlugin/ViewModels/CurrentMessagesViewModel.cs
@@ -646,6 +646,9 @@ public partial class CurrentMessagesViewModel : ObservableObject, IRecipient<Dia
     {
         try
         {
+            if (currentMessageViewModel.Message.IsAcknowledged)
+                return;
+
             await _mediator.Send(new AcknowledgeDownlinkMessageRequest(
                 currentMessageViewModel.Dialogue.Id,
                 currentMessageViewModel.Message.MessageId));

--- a/source/CPDLCPlugin/Windows/CurrentMessagesWindow.xaml.cs
+++ b/source/CPDLCPlugin/Windows/CurrentMessagesWindow.xaml.cs
@@ -84,6 +84,9 @@ public partial class CurrentMessagesWindow : Window
         {
             ActionPopup.IsOpen = true;
         }
+
+        // Prevent the click from bubbling to Message_MouseLeftButtonDown
+        e.Handled = true;
     }
 
     void Message_MouseRightButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
Two causes for the spam in #27:

- WPF event bubbling: clicking the callsign (a child element of the message row) fired both `Callsign_MouseLeftButtonDown` and `Message_MouseLeftButtonDown`, sending two acknowledgements per click. Fixed by setting `e.Handled = true` in the callsign handler.
- No idempotency guard: every click on an already-acknowledged downlink re-sent the acknowledgement. Fixed by checking `IsAcknowledged` before sending the request.

Closes #27